### PR TITLE
Stick to hex colors per simplestyle spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,5 +95,5 @@ function formatColor(str) {
     if (!str) return null;
     var parsed = csscolorparser('#' + str);
     if (!parsed) return null;
-    return 'rgba(' + parsed.join(',') + ')';
+    return '#' + str;
 }

--- a/test.js
+++ b/test.js
@@ -95,9 +95,9 @@ test('stringToFeature', function(t) {
                 type: 'LineString'
             },
             properties: {
-                fill: 'rgba(102,136,170,1)',
+                fill: '#68a',
                 'fill-opacity': '0.25',
-                stroke: 'rgba(255,68,68,1)',
+                stroke: '#f44',
                 'stroke-opacity': '0.5',
                 'stroke-width': '2'
             },
@@ -112,9 +112,9 @@ test('stringToFeature', function(t) {
                 type: 'LineString'
             },
             properties: {
-                fill: 'rgba(102,136,170,1)',
+                fill: '#68a',
                 'fill-opacity': '0.25',
-                stroke: 'rgba(255,68,68,1)',
+                stroke: '#f44',
                 'stroke-opacity': '0.5',
                 'stroke-width': '2.25'
             },


### PR DESCRIPTION
Switch fill/stroke to be hex color values rather than rgba.
