### PR TITLE
Return errors rather than nulls on non-matching geojson/path

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function stringToFeature(str) {
         }];
     } else if (isGeoJSON) {
         marker = str.match(matchGeoJSON);
-        if (!marker) return null;
+        if (!marker) return new Error('Invalid geojson syntax');
         try {
             if (geojsonhint.hint(marker[1]).length) {
                 return new Error('Invalid GeoJSON');
@@ -45,7 +45,7 @@ module.exports = function stringToFeature(str) {
         }
     } else if (isPolyline) {
         marker = str.match(matchPath);
-        if (!marker) return null;
+        if (!marker) return new Error('Invalid path syntax');
         var properties = {
             'stroke-width': marker[2],
             stroke: formatColor(marker[4]),
@@ -57,9 +57,9 @@ module.exports = function stringToFeature(str) {
             if (!properties[k]) delete properties[k];
         });
         var encodedLine = marker[11];
-        if (!encodedLine) return null;
+        if (!encodedLine) return new Error('Invalid polyline');
         var decoded = polyline.decode(encodedLine);
-        if (!decoded) return null;
+        if (!decoded) return new Error('Invalid polyline');
         var feature = [{
             type: 'Feature',
             properties: properties,

--- a/test.js
+++ b/test.js
@@ -129,11 +129,11 @@ test('stringToFeature', function(t) {
             properties: {},
             geometry: point
         }], 'geojson(point)');
-
     t.equal(stringToFeature('url-google.com(,)').message, 'Invalid marker: url-google.com(,)', 'invalid');
     t.equal(stringToFeature('pin-m(,)').message, 'Invalid marker: pin-m(,)', 'invalid');
     t.equal(stringToFeature('gibberish').message, 'Invalid marker: gibberish', 'invalid');
-    t.equal(stringToFeature('path('), null, 'invalid');
+    t.equal(stringToFeature('path(').message, 'Invalid path syntax', 'invalid');
+    t.equal(stringToFeature('path-2.25+f444-0.5+68a-0.25(').message, 'Invalid path syntax', 'invalid');
     t.equal(stringToFeature('geojson(hi').message, 'Invalid GeoJSON', 'invalid');
 
     t.end();


### PR DESCRIPTION
No more `null` returns -- either a geojson feature comes back or it's an error.
